### PR TITLE
AWS 과금 리포트 가시성 개선 

### DIFF
--- a/monitor/aws_usage_report_to_slack.py
+++ b/monitor/aws_usage_report_to_slack.py
@@ -46,7 +46,7 @@ def generate_slack_message(result):
                       for service, details in result.items()}
 
     # 결과 출력을 위한 문자열 생성
-    output_str = "Acount: " + account_name + "Daily Total : " + str(total_price) + "$\n"
+    output_str = "Acount: " + account_name + "\nDaily Total : " + str(total_price) + "$\n"
 
     for service, price in sorted_services:
         if price == 0:

--- a/monitor/aws_usage_report_to_slack.py
+++ b/monitor/aws_usage_report_to_slack.py
@@ -46,18 +46,18 @@ def generate_slack_message(result):
                       for service, details in result.items()}
 
     # 결과 출력을 위한 문자열 생성
-    output_str = "Acount: " + account_name + "\nDaily Total : " + str(total_price) + "$\n"
+    output_str = "Acount: " + account_name + "\nDaily Total : $" + str(total_price) + "\n"
 
     for service, price in sorted_services:
         if price == 0:
             continue
-        output_str += f"{service}: {price}$\n"
+        output_str += f"{service}: ${price}\n"
         for detail in sorted_details[service]:
             detail_name = list(detail.keys())[0]
             detail_price = float(list(detail.values())[0])
             if detail_price == 0:
                 continue
-            output_str += f"        {detail_name}: {detail_price}$\n"
+            output_str += f"        {detail_name}: ${detail_price}\n"
         output_str += "\n\n"
 
     return output_str


### PR DESCRIPTION
<img width="461" alt="image" src="https://github.com/ddps-lab/cloud-usage/assets/106056971/503ce2c9-4286-45f0-8e59-58591ac7c242">


기존 cloud-usage채널 과금 리포트는 위와같이 모든 사용량이 가격순으로 정렬되 어떤 서비스에서 어떤것이 과금되었는지 한눈에 들어오지 않았습니다.
이를 개선하기 위해 EC2, S3, CloudWatch등 어떤 서비스에서 얼마만큼 과금이 되었는지 들여쓰기로 구분해 가시성이 좋게 개선하였습니다.

슬랙에 전송된 결과는 아래와 같습니다.

<img width="586" alt="Screenshot 2023-10-19 at 17 27 06" src="https://github.com/ddps-lab/cloud-usage/assets/106056971/62d6c302-d6fd-4864-be42-bf7dd47f9a84">

