### PR TITLE
Debuging: Debug error for ec2 report

### DIFF
--- a/monitor/ec2_management/aws_ec2_report_to_slack.py
+++ b/monitor/ec2_management/aws_ec2_report_to_slack.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone, timedelta
 from slack_msg_sender import send_slack_message
 
 
-SLACK_URL = os.environ['SLACK_URL']
+SLACK_URL = os.environ['SLACK_DDPS']
 
 # instance management : 모든 리전의 인스턴스와 볼륨 탐색 및 리스트 반환
 def instance_management(current_time):
@@ -58,8 +58,7 @@ def get_instance_items(current_time, regions):
 
                     # 인스턴스의 볼륨ID 확인
                     for mapping in instance['BlockDeviceMappings']:
-                        if mapping['DeviceName'] == '/dev/sda1':
-                            volume_id = mapping['Ebs']['VolumeId']
+                        volume_id = mapping['Ebs']['VolumeId']
 
                     # 인스턴스 저장
                     instance_dsc = {'region':ec2_region, 'info':instance_info, 'type':instance_type, 'volume':volume_id, 'time_days':days, 'time_hours':hours, 'time_minutes':minutes}


### PR DESCRIPTION
11월 9일 오후 10시, 인스턴스 동작에 에러가 발생하여 디버그를 진행하였습니다.

인스턴스와 볼륨이 매치되지 않아 발생한 에러였으며, 우선은 임시 조치를 취해둔 후 작업을 진행하였습니다.

`ca-central-1 / i-00000001 / t2.micro / none`

위 인스턴스에서 블록 디바이스 디스크를 다른 것(`/dev/xvda`)을 이용하고 있어 볼륨 아이디 매핑이 제대로 되지 않았습니다.
이전까지는 대게 `/dev/sda1` 디스크를 이용하다 보니, 코드에 불필요하게 해당 디스크를 이용해야만 볼륨 아이디 정보를 저장하게끔 작성되어 있었습니다.
이를 발견하였고 어떤 디스크를 이용하여도 볼륨 아이디 정보를 저장할 수 있도록 코드를 수정하였습니다.
에러 디버깅을 완료하였고, 정상 작동을 확인하여 이 내용을 코멘트합니다.

또한, 여러 차례 디버깅을 진행하는 점에서 기존 슬랙 주소와 테스트 슬랙 주소를 모두 환경 변수로 세팅해두었습니다.
이는 변수명으로 아웃풋 슬랙 주소를 바꿀 수 있게 변경해두었습니다.