### PR TITLE
add the user name in usage report

### DIFF
--- a/monitor/spot_management/aws_daily_instance_usage_report.py
+++ b/monitor/spot_management/aws_daily_instance_usage_report.py
@@ -225,9 +225,16 @@ def get_run_instance_information(events, run_instance_id, daily_instances):
 
     try:
         name_tag = event_informations['requestParameters']['tagSpecificationSet']['items'][0]['tags'][0]['value']
+        if name_tag[:4] == "sfr-":
+            name_tag = "spot fleet"
         daily_instances[run_instance_id]['NameTag'] = name_tag
+        if len(daily_instances[run_instance_id].get('UserName')) > 10:
+            for resource in events.get('Resources'):
+                if resource.get('ResourceType') == 'AWS::EC2::KeyPair':
+                    daily_instances[run_instance_id]['UserName'] = resource.get('ResourceName')
     except Exception:
         daily_instances[run_instance_id]['NameTag'] = daily_instances[run_instance_id]['UserName']
+        daily_instances[run_instance_id]['UserName'] = "aws"
 
     return daily_instances
 
@@ -293,7 +300,7 @@ def create_message(region, all_daily_instance, search_date):
                     continue
 
                 # create the message about instance usage
-                usage_message = f"{' ':>8}{all_daily_instance[instance_id]['NameTag']} ({instance_id}) / {all_daily_instance[instance_id]['InstanceType']} / "
+                usage_message = f"{' ':>8}{all_daily_instance[instance_id]['NameTag']} ({all_daily_instance[instance_id]['UserName']}, {instance_id}) / {all_daily_instance[instance_id]['InstanceType']} / "
 
                 if state_running:
                     usage_message += f"인스턴스 실행 중 ({run_time})\n"


### PR DESCRIPTION
#43 이슈의 내용을 코드로 구현합니다.

우선 daily usage report 부터 수정하였습니다.
<img width="740" alt="image" src="https://github.com/ddps-lab/cloud-usage/assets/65997015/93f7a7a3-b201-4eea-a1f9-fc996d3a8464">

<img width="759" alt="image" src="https://github.com/ddps-lab/cloud-usage/assets/65997015/774c2659-682c-4a46-8844-ce8774003fc1">

수정된 내용은 다음과 같습니다.
1. 어떤 user의 인스턴스인지 명확히 표시합니다.
  - 단, aws 내에서 생성된 경우 기존 InstanceLaunch에서 aws로 보이게 수정하였습니다.
2. spot fleet으로 생성된 경우 인스턴스 키의 네임을 가져옵니다.
  - 랩실의 User Name은 보통 10자 이내라는 점을 이용하여, user name이 10자 이상일 경우에만 key mame으로 받아오게 설정하였습니다.
  - 또한, spot fleet의 이름은 `sfr-`로 시작하는 접두사가 특징적이며, 인스턴스의 이름이 상당히 길어 모니터링 길이가 길어지는 것 같아 임의로 spot fleet이라는 이름을 부여하였습니다.
  - 위 spot fleet의 이름이 붙는 것보다 그냥 이름이 붙는 것이 나으실 거라고 판단하면 코드 수정하도록 하겠습니다.

이어서 run & stop report 수정하겠습니다.