### PR TITLE
Debug the error and Add the exception message gor debugging

### DIFF
--- a/monitor/ec2_management/aws_ec2_report_to_slack.py
+++ b/monitor/ec2_management/aws_ec2_report_to_slack.py
@@ -104,7 +104,7 @@ def get_volume_items(regions):
         sorted_orphaned_volumes = sorted(orphaned_volumes, key=lambda x: (x['time']), reverse=True)
         return sorted_orphaned_volumes
     except Exception as e:
-        print(f"볼륨 조회 실패\n{e}")
+        send_slack_message(f"볼륨 조회 실패\n{e}")
 
 
 # created message : 인스턴스 및 볼륨 리스트를 메세지로 생성

--- a/monitor/ec2_management/aws_ec2_report_to_slack.py
+++ b/monitor/ec2_management/aws_ec2_report_to_slack.py
@@ -164,7 +164,7 @@ def lambda_handler(event, context):
     utc_time = datetime.now(timezone.utc)
     korea_time = (utc_time + timedelta(hours=9)).strftime("%Y-%m-%d %H:%M")
 
-    head_message = f"Account: test@ddps.com\n"
+    head_message = f"Account: {os.environ['EMAIL']}\n"
     head_message += (korea_time+"\n")
 
     running_instances, stopped_instances, orphaned_volumes = 0, 0, 0

--- a/monitor/spot_management/aws_daily_instance_usage_report.py
+++ b/monitor/spot_management/aws_daily_instance_usage_report.py
@@ -139,7 +139,6 @@ def get_stop_instances(mode, cloudtrail, response, all_daily_instance):
 
         if instance_ids == None:
             continue
-
         try:
             for instance_id, _ in instance_ids:
                 # add the stop time information of instance to daily instance list
@@ -273,7 +272,7 @@ def get_spot_requests_information(region, instance_id, request_id):
         if response['Events'][0]['EventName'] == 'RequestSpotInstances':
             event_informations = json.loads(response['Events'][0].get('CloudTrailEvent'))
             valid_until = event_informations['requestParameters'].get('validUntil')
-            stop_time = (datetime.fromtimestamp(valid_until/1000)).replace(microsecond=0)
+            stop_time = (datetime.fromtimestamp(valid_until/1000)).replace(microsecond=0, tzinfo=timezone.utc)
         return stop_time
     except:
         return None
@@ -387,7 +386,9 @@ def lambda_handler(event, context):
     # setting datetime informations for searching daily logs in cloud trail service
     global search_datetime, start_datetime, end_datetime
     utc_datetime = datetime.now(timezone.utc)
-    search_datetime = utc_datetime + timedelta(days=-1, hours=9)
+    if utc_datetime.hour < 15:
+        utc_datetime += timedelta(days=-1)
+    search_datetime = utc_datetime + timedelta(hours=9)
     start_datetime = ((utc_datetime + timedelta(days=-1, hours=9)).astimezone(timezone(timedelta(hours=9)))).replace(hour=0, minute=0, second=0, microsecond=0)
     end_datetime = ((utc_datetime + timedelta(days=-1, hours=9)).astimezone(timezone(timedelta(hours=9)))).replace(hour=23, minute=59, second=59, microsecond=0)
 

--- a/monitor/spot_management/aws_daily_instance_usage_report.py
+++ b/monitor/spot_management/aws_daily_instance_usage_report.py
@@ -12,34 +12,35 @@ SLACK_URL = os.environ['SLACK_DDPS']
 
 
 # daily_instance_usage() : Collect instance information that 'run', 'start', 'terminate', and 'stop' for each region.
-def daily_instance_usage(region, end_date):
+def daily_instance_usage(region):
     all_daily_instance = {}
     search_modes = ["RunInstances", "StartInstances", "TerminateInstances", "StopInstances"]
+    check_mode = [True, True, False, False]
     
     # store cloud trail logs of all region
     try:
-        for mode in search_modes:
+        for i, mode in enumerate(search_modes):
             cloudtrail = boto3.client('cloudtrail', region_name=region)
 
             response_list = []
-            token, response = search_instances(cloudtrail, "EventName", mode, False, end_date + timedelta(days=-1), end_date, None)
+            token, response = search_instances(cloudtrail, "EventName", mode, False, 0, None)
             response_list.append(response)
 
             while(token):
                 if response.get('NextToken') != None:
                     token_code = response['NextToken']
 
-                token, response = search_instances(cloudtrail, "EventName", mode, token, end_date + timedelta(days=-1), end_date, token_code)
+                token, response = search_instances(cloudtrail, "EventName", mode, token, 0, token_code)
                 response_list.append(response)
             
             # call the following functions according to the selected mode
             # parameter description : prevents duplicate searches, act the selected mode, and extracts data from results
             for response in response_list:
-                if mode == "RunInstances" or mode == "StartInstances":
-                    all_daily_instance = get_start_instances(mode, cloudtrail, response, all_daily_instance, end_date)
+                if check_mode[i]:
+                    all_daily_instance = get_start_instances(mode, cloudtrail, response, all_daily_instance)
                 else:
-                    all_daily_instance = get_stop_instances(mode, cloudtrail, response, all_daily_instance, end_date)
-                         
+                    all_daily_instance = get_stop_instances(mode, cloudtrail, response, all_daily_instance)
+
     except KeyError as keyerror:
         send_slack_message(f'daily_instance_usage() : KeyError in relation to "{keyerror}" in "{region}"')
     except Exception as e:
@@ -49,35 +50,31 @@ def daily_instance_usage(region, end_date):
 
 
 # search_instances() : search the instance as cloud trail service.
-def search_instances(cloudtrail, eventname, item, token, start_date, end_date, token_code):
-    # transformated unix timestamp because of cloud trail service searching condition
-    end_time = int(datetime(int(end_date.strftime("%Y")), int(end_date.strftime("%m")), int(end_date.strftime("%d")), 15, 0, 0).timestamp())
-    start_time = int(datetime(int(start_date.strftime("%Y")), int(start_date.strftime("%m")), int(start_date.strftime("%d")), 15, 0, 0).timestamp())
-
+def search_instances(cloudtrail, eventname, item, token, period, token_code):
     # search the instances
     response = []
     if token:
         response = cloudtrail.lookup_events(
-            EndTime = end_time,
+            EndTime = end_datetime,
             LookupAttributes = [
                 {
                     "AttributeKey": eventname,
                     "AttributeValue": item
                 },
             ],
-            StartTime = start_time,
+            StartTime = (start_datetime - timedelta(days=period)),
             NextToken = token_code
         )
     else:
         response = cloudtrail.lookup_events(
-            EndTime = end_time,
+            EndTime = end_datetime,
             LookupAttributes = [
                 {
                     "AttributeKey": eventname,
                     "AttributeValue": item
                 },
             ],
-            StartTime = start_time
+            StartTime = (start_datetime - timedelta(days=period))
         )
 
     if response.get('NextToken') == None:
@@ -88,7 +85,7 @@ def search_instances(cloudtrail, eventname, item, token, start_date, end_date, t
 
 
 # get_start_instances() : It stores the instance information of the 'run' and 'start' state.
-def get_start_instances(mode, cloudtrail, response, all_daily_instance, END_DATE):
+def get_start_instances(mode, cloudtrail, response, all_daily_instance):
     for events in response['Events']:
         instance_ids, event_time = get_instance_ids(events)
 
@@ -109,7 +106,7 @@ def get_start_instances(mode, cloudtrail, response, all_daily_instance, END_DATE
                 if mode == "RunInstances":
                     all_daily_instance = get_run_instance_information(events, instance_id, all_daily_instance)
                 else:
-                    all_daily_instance = search_instance_information(cloudtrail, instance_id, all_daily_instance, END_DATE)
+                    all_daily_instance = search_instance_information(cloudtrail, instance_id, all_daily_instance)
 
             # add the start time information of instance to daily instance list
             else:
@@ -123,7 +120,7 @@ def get_start_instances(mode, cloudtrail, response, all_daily_instance, END_DATE
 
 
 # get_stop_instances() : It stores the instance information of the 'terminate' and 'stop' state.
-def get_stop_instances(mode, cloudtrail, response, all_daily_instance, end_date):
+def get_stop_instances(mode, cloudtrail, response, all_daily_instance):
     for events in response['Events']:
         instance_ids, event_time = get_instance_ids(events)
 
@@ -133,30 +130,28 @@ def get_stop_instances(mode, cloudtrail, response, all_daily_instance, end_date)
         for instance_id, _ in instance_ids:
             # add the stop time information of instance to daily instance list
             if instance_id in all_daily_instance:
-                for sequence in range(0, len(all_daily_instance[instance_id]['state'])):
-                    search_date = end_date + timedelta(days=-1)
-                    search_start_time = datetime(int(search_date.strftime("%Y")), int(search_date.strftime("%m")), int(search_date.strftime("%d")), 15, 0, 0)
-                    start_time = all_daily_instance[instance_id]['state'][sequence].get('StartTime')
-                    if search_start_time == start_time and len(all_daily_instance[instance_id]['state']) == 1:
-                        if all_daily_instance[instance_id]['state'][sequence].get('StopTime') > event_time:
+                for sequence, instance_state in enumerate(all_daily_instance[instance_id]['state']):
+                    start_time = instance_state.get('StartTime')
+                    if start_datetime == start_time and len(all_daily_instance[instance_id]['state']) == 1:
+                        if instance_state.get('StopTime') > event_time:
                             del all_daily_instance[instance_id]
-                            add_new_instance_information(cloudtrail, instance_id, all_daily_instance, event_time, end_date)
+                            add_new_instance_information(cloudtrail, instance_id, all_daily_instance, event_time)
                         continue
 
                     if start_time <= event_time:
-                        all_daily_instance[instance_id]['state'][sequence]['StopTime'] = event_time
+                        instance_state['StopTime'] = event_time
                     else:
                         previous_start_time = all_daily_instance[instance_id]['state'][sequence-1].get('StartTime')
                         previous_stop_time = all_daily_instance[instance_id]['state'][sequence-1].get('StopTime')
-                        if previous_start_time != None and previous_start_time < event_time and previous_stop_time > event_time:
+                        if previous_start_time != None and previous_stop_time != None and previous_start_time < event_time and previous_stop_time > event_time:
                             all_daily_instance[instance_id]['state'][sequence-1]['StopTime'] = event_time
-            
+
             # store new instance information
             else:
                 # Start only terminate
                 if mode == "TerminateInstances":
                     continue
-                add_new_instance_information(cloudtrail, instance_id, all_daily_instance, event_time, end_date)
+                all_daily_instance = add_new_instance_information(cloudtrail, instance_id, all_daily_instance, event_time)
     return all_daily_instance
 
 
@@ -178,78 +173,81 @@ def get_instance_ids(events):
         if event_informations['responseElements'].get('omitted'):
             return None, 0
         instances = event_informations['responseElements']['instancesSet']['items']
-        for n in range(len(instances)):
-            instance_ids.append((instances[n]['instanceId'], instances[n].get('spotInstanceRequestId')))
+        for instance in instances:
+            instance_ids.append((instance.get('instanceId'), instance.get('spotInstanceRequestId', '')))
             
-    event_time = events['EventTime'].replace(tzinfo=None)
+    event_time = events['EventTime'].replace(tzinfo=timezone.utc)
 
     return instance_ids, event_time
 
 
 # add_new_instance_information() : Collect information when the input instance has new information
-def add_new_instance_information(cloudtrail, instance_id, all_daily_instance, event_time, end_date):
-    search_date = end_date + timedelta(days=-1)
-    search_start_time = datetime(int(search_date.strftime("%Y")), int(search_date.strftime("%m")), int(search_date.strftime("%d")), 15, 0, 0)
-    all_daily_instance[instance_id] = {'state': [{'StartTime': search_start_time,'StopTime': event_time}]}
-    all_daily_instance = search_instance_information(cloudtrail, instance_id, all_daily_instance, end_date)
+def add_new_instance_information(cloudtrail, instance_id, all_daily_instance, event_time):
+    all_daily_instance[instance_id] = {'state': [{'StartTime': start_datetime,'StopTime': event_time}]}
+    all_daily_instance = search_instance_information(cloudtrail, instance_id, all_daily_instance)
     return all_daily_instance
 
 
 # search_instance_information() : Call other functions to get information about the 'run instance'.
-def search_instance_information(cloudtrail, run_instance_id, daily_instances, end_date):
-    token, response = search_instances(cloudtrail, "ResourceName", run_instance_id, False, end_date + timedelta(days=-90), end_date, None)
+def search_instance_information(cloudtrail, run_instance_id, all_daily_instance):
+    token, response = search_instances(cloudtrail, "ResourceName", run_instance_id, False, 88, None)
 
     if token:
         while(token):
-            token, response = search_instances(cloudtrail, "ResourceName", run_instance_id, token, end_date + timedelta(days=-90), end_date, response['NextToken'])
+            token, response = search_instances(cloudtrail, "ResourceName", run_instance_id, token, 88, response['NextToken'])
     for events in response['Events']:
         if events.get('EventName') == 'RunInstances':
-            daily_instances = get_run_instance_information(events, run_instance_id, daily_instances)
+            all_daily_instance = get_run_instance_information(events, run_instance_id, all_daily_instance)
+    if all_daily_instance[run_instance_id].get('UserName') is None:
+        for events in response['Events']:
+            if events.get('EventName') in ['StartInstances', 'StopInstances', 'TerminateInstances']:
+                all_daily_instance[run_instance_id]['UserName'] = events.get('Username')
+                break
     
-    return daily_instances
+    return all_daily_instance
 
 
 # get_run_instance_information() : Store the necessary information from the extracted data.
-def get_run_instance_information(events, run_instance_id, daily_instances):
+def get_run_instance_information(events, run_instance_id, all_daily_instance):
     event_informations = json.loads(events.get('CloudTrailEvent'))
-    daily_instances[run_instance_id]['InstanceType'] = event_informations['requestParameters'].get('instanceType')
-    daily_instances[run_instance_id]['UserName'] = events.get('Username')
+    all_daily_instance[run_instance_id]['InstanceType'] = event_informations['requestParameters'].get('instanceType')
+    all_daily_instance[run_instance_id]['UserName'] = events.get('Username')
 
     if event_informations['requestParameters'].get('instancesSet') != None:
-        daily_instances[run_instance_id]['KeyName'] = event_informations['requestParameters']['instancesSet']['items'][0].get('keyName')
+        all_daily_instance[run_instance_id]['KeyName'] = event_informations['requestParameters']['instancesSet']['items'][0].get('keyName')
 
     if event_informations['requestParameters'].get('instanceMarketOptions') != None:
-        daily_instances[run_instance_id]['Spot'] = True
+        all_daily_instance[run_instance_id]['Spot'] = True
     else:
-        daily_instances[run_instance_id]['Spot'] = False
+        all_daily_instance[run_instance_id]['Spot'] = False
 
     try:
         name_tag = event_informations['requestParameters']['tagSpecificationSet']['items'][0]['tags'][0]['value']
         if name_tag[:4] == "sfr-":
             name_tag = "spot fleet"
-        daily_instances[run_instance_id]['NameTag'] = name_tag
-        if len(daily_instances[run_instance_id].get('UserName')) > 10:
+        all_daily_instance[run_instance_id]['NameTag'] = name_tag
+        if len(all_daily_instance[run_instance_id].get('UserName')) > 10:
             for resource in events.get('Resources'):
                 if resource.get('ResourceType') == 'AWS::EC2::KeyPair':
-                    daily_instances[run_instance_id]['UserName'] = resource.get('ResourceName')
+                    all_daily_instance[run_instance_id]['UserName'] = resource.get('ResourceName')
     except Exception:
-        daily_instances[run_instance_id]['NameTag'] = daily_instances[run_instance_id]['UserName']
-        daily_instances[run_instance_id]['UserName'] = "aws"
+        all_daily_instance[run_instance_id]['NameTag'] = all_daily_instance[run_instance_id]['UserName']
+        all_daily_instance[run_instance_id]['UserName'] = "aws"
 
-    return daily_instances
+    return all_daily_instance
 
 
 # get_spot_requests_information() : Find the stop time recorded on spot request
-def get_spot_requests_information(region, instance_id, search_date, request_id):
+def get_spot_requests_information(region, instance_id, request_id):
     try:
         cloudtrail = boto3.client('cloudtrail', region_name=region)
         if request_id == None:
-            token, response = search_instances(cloudtrail, 'Username', instance_id, False, search_date + timedelta(days=-1), search_date, None)
+            _, response = search_instances(cloudtrail, 'Username', instance_id, False, 0, None)
             for events in response['Events']:
                 if events.get('EventName') == 'DescribeSpotInstanceRequests':
                     event_informations = json.loads(events.get('CloudTrailEvent'))
                     request_id = event_informations['requestParameters']['spotInstanceRequestIdSet']['items'][0].get('spotInstanceRequestId')
-        token, response = search_instances(cloudtrail, 'ResourceName', request_id, False, search_date + timedelta(days=-1), search_date, None)
+        _, response = search_instances(cloudtrail, 'ResourceName', request_id, False, 0, None)
         if response['Events'][0]['EventName'] == 'RequestSpotInstances':
             event_informations = json.loads(response['Events'][0].get('CloudTrailEvent'))
             valid_until = event_informations['requestParameters'].get('validUntil')
@@ -260,7 +258,7 @@ def get_spot_requests_information(region, instance_id, search_date, request_id):
     
 
 # create_message() : Create a message to send to Slack.
-def create_message(region, all_daily_instance, search_date):
+def create_message(region, all_daily_instance):
     message = {'spot': ["",],  'request': "", 'on_demand': ["",]}
     instance_count = 0
     experiment_count = 0
@@ -270,21 +268,21 @@ def create_message(region, all_daily_instance, search_date):
                 message['request'] += f"{' ':>12}이외 스팟리퀘스트 요청이 {all_daily_instance['SpotRquests']['Number']}건 실행되었습니다.\n"
                 continue
         
-            for sequence in range(0, len(all_daily_instance[instance_id]['state'])):
+            for sequence, instance_state in enumerate(all_daily_instance[instance_id]['state']):
                 state_running = False
                 # when time information about start and stop be in all daily instance
                 try:
-                    run_time = all_daily_instance[instance_id]['state'][sequence]['StopTime'] - all_daily_instance[instance_id]['state'][sequence]['StartTime']
+                    run_time = instance_state['StopTime'] - instance_state['StartTime']
 
                 # when time information about start or stop not be in all daily instance
                 except KeyError:
                     if sequence == len(all_daily_instance[instance_id]['state']) - 1:
                         spot_request_id = all_daily_instance[instance_id].get('spot_request_id')
-                        stop_time = get_spot_requests_information(region, instance_id, search_date, spot_request_id)
+                        stop_time = get_spot_requests_information(region, instance_id, spot_request_id)
                         if stop_time != None:
-                            run_time = stop_time - all_daily_instance[instance_id]['state'][sequence]['StartTime']
+                            run_time = stop_time - instance_state['StartTime']
                         else:
-                            run_time = datetime(int(search_date.strftime("%Y")), int(search_date.strftime("%m")), int(search_date.strftime("%d")), 15, 0, 0) - all_daily_instance[instance_id]['state'][sequence]['StartTime']
+                            run_time = end_datetime - instance_state['StartTime']
                             if all_daily_instance[instance_id]['UserName'] == "InstanceLaunch" and all_daily_instance[instance_id]['KeyName'] == None:
                                 run_time = timedelta(days=0, seconds=0)
                             else:
@@ -295,13 +293,16 @@ def create_message(region, all_daily_instance, search_date):
                 if run_time.days == -1:
                     run_time = (-run_time)
 
-                if run_time.seconds < 3:
+                if run_time.seconds < 5:
                     instance_count += 1
                     experiment_count += 1
                     continue
 
                 # create the message about instance usage
-                usage_message = f"{' ':>8}{all_daily_instance[instance_id]['NameTag']} ({all_daily_instance[instance_id]['UserName']}, {instance_id}) / {all_daily_instance[instance_id]['InstanceType']} / "
+                if all_daily_instance[instance_id].get('InstanceType') is not None:
+                    usage_message = f"{' ':>8}{all_daily_instance[instance_id]['NameTag']} ({all_daily_instance[instance_id]['UserName']}, {instance_id}) / {all_daily_instance[instance_id]['InstanceType']} / "
+                else:
+                    usage_message = f"{' ':>8}{all_daily_instance[instance_id]['UserName']} ({all_daily_instance[instance_id]['UserName']}, {instance_id}) / Not-Found / "
 
                 if state_running:
                     usage_message += f"인스턴스 실행 중 ({run_time})\n"
@@ -309,7 +310,7 @@ def create_message(region, all_daily_instance, search_date):
                     usage_message += f"{run_time} 간 실행\n"
 
                 # add message depending on whether spot instance is enabled
-                if all_daily_instance[instance_id]['Spot'] == True:
+                if all_daily_instance[instance_id].get('Spot') in [True, None]:
                     if len(message['spot'][len(message['spot'])-1]) < 3950:
                         message['spot'][len(message['spot'])-1] += usage_message
                     else:
@@ -322,9 +323,9 @@ def create_message(region, all_daily_instance, search_date):
                 instance_count += 1
 
     except KeyError:
-        send_slack_message("create_message() : A problem collecting instance information. Related functions is get_run_instance_information()")
+        print(f"create_message() : A problem collecting instance information. Related functions is get_run_instance_information() in {region}")
     except Exception as e:
-        send_slack_message(f"create_message() : Exception in relation to {e}")
+        print(f"create_message() : Exception in relation to <{e}> in {region}")
     
     report_message = [f'{region} ({instance_count})\n']
     for kind in message:
@@ -361,10 +362,15 @@ def push_slack(message):
 
 
 def lambda_handler(event, context):
-    # date information for searching daily logs in cloud trail service
-    record_time = datetime.now(timezone.utc) + timedelta(hours=9)
-    search_date = datetime.now(timezone.utc) + timedelta(days=-1, hours=9)
-    header = f"*Daily Instances Usage Report (DATE: {search_date.strftime('%Y-%m-%d')})*"
+    # setting datetime informations for searching daily logs in cloud trail service
+    global search_datetime, start_datetime, end_datetime
+    utc_datetime = datetime.now(timezone.utc)
+    search_datetime = utc_datetime + timedelta(days=-1, hours=9)
+    start_datetime = ((utc_datetime + timedelta(days=-1, hours=9)).astimezone(timezone(timedelta(hours=9)))).replace(hour=0, minute=0, second=0, microsecond=0)
+    end_datetime = ((utc_datetime + timedelta(days=-1, hours=9)).astimezone(timezone(timedelta(hours=9)))).replace(hour=23, minute=59, second=59, microsecond=0)
+
+    # creating head message
+    header = f"*Daily Instances Usage Report (DATE: {search_datetime.strftime('%Y-%m-%d')})*"
     all_message = []
     stop_message = [False, "*생성된 인스턴스의 수가 많아 인스턴스 사용량 전달을 중단합니다.*"]
 
@@ -372,15 +378,15 @@ def lambda_handler(event, context):
     ec2 = boto3.client('ec2')
     regions = [region['RegionName'] for region in ec2.describe_regions()['Regions']]
     for region in regions:
-        if ((datetime.now(timezone.utc) + timedelta(hours=9)) - record_time).seconds > 270:
+        if (datetime.now(timezone.utc) - utc_datetime).seconds > 270:
             stop_message[0] = True
             break
             
-        all_daily_instance = daily_instance_usage(region, search_date)
+        all_daily_instance = daily_instance_usage(region)
 
         # created message to slack and pushed to slack
         if len(all_daily_instance) != 0:
-            all_message.append(create_message(region, all_daily_instance, search_date))
+            all_message.append(create_message(region, all_daily_instance))
          
     push_slack(header)
     if len(all_message) != 0:


### PR DESCRIPTION
### None 타입과 비교 연산자 사용 에러
기존 148~152 줄에서 발생하던 "None 타입과 비교 연산자 사용" 에러를 다음과 같이 수정하였습니다.
<기존>
```py
  else:
      previous_start_time = all_daily_instance[instance_id]['state'][sequence-1].get('StartTime')
      previous_stop_time = all_daily_instance[instance_id]['state'][sequence-1].get('StopTime')
      if previous_start_time != None and previous_start_time < event_time and previous_stop_time > event_time:
          all_daily_instance[instance_id]['state'][sequence-1]['StopTime'] = event_time
```

<수정>
```py
  else:
      previous_start_time = all_daily_instance[instance_id]['state'][sequence-1].get('StartTime')
      previous_stop_time = all_daily_instance[instance_id]['state'][sequence-1].get('StopTime')
      if previous_start_time != None and previous_stop_time != None and previous_start_time < event_time and previous_stop_time > event_time:
          all_daily_instance[instance_id]['state'][sequence-1]['StopTime'] = event_time
```

### RunInstance cloudtrail 이벤트 말소로 인한 에러
기존에 인스턴스 타입이나 사용자에 대한 정보를 가져오기 위해서는 반드시 RunInstances 이벤트를 확인했어야 하는데, cloudtrail의 경우 90일이 지나면 이벤트를 aws 자체적으로 삭제합니다. 이로 인해 90일 이전에 생성된 인스턴스는 RunInstances 이벤트를 찾을 수 없어 에러를 발생하였습니다.
다음과 같은 코드를 추가하여 디버깅 진행하였습니다.

```py
    if all_daily_instance[run_instance_id].get('UserName') is None:
        for events in response['Events']:
            if events.get('EventName') in ['StartInstances', 'StopInstances', 'TerminateInstances']:
                all_daily_instance[run_instance_id]['UserName'] = events.get('Username')
                break
```

### 추가적인 코드 수정
기존에 이벤트 쿼리를 위해 설정하였던 datetime 정보와 관련하여 무조건 utc timezone 을 이용하도록 하여 datetime 계산에 에러를 발생하지 않게 하였고, 여러 번 계산하던 datetime 정보는 함수를 처음 실행하였을 때, global 변수로 선언하게 수정하였습니다.
```py
global search_datetime, start_datetime, end_datetime
utc_datetime = datetime.now(timezone.utc)
search_datetime = utc_datetime + timedelta(days=-1, hours=9)
start_datetime = ((utc_datetime + timedelta(days=-1, hours=9)).astimezone(timezone(timedelta(hours=9)))).replace(hour=0, minute=0, second=0, microsecond=0)
end_datetime = ((utc_datetime + timedelta(days=-1, hours=9)).astimezone(timezone(timedelta(hours=9)))).replace(hour=23, minute=59, second=59, microsecond=0)
```

### 디버깅을 위한 메세지 추가
그 외에 디버깅이 조금 더 용이할 수 있도록 try, exception 문을 잘게 쪼개 코드에 삽입하였습니다. 추후 에러가 발생하면 좀 더 세분화되어 디버깅 시간을 아낄 수 있도록 하였습니다.

---

코드 리뷰 및 일주일 동안 모니터링 기간을 거친 후 머지하도록 하겠습니다.